### PR TITLE
Auto search-and-replace of old repo references

### DIFF
--- a/DX/BDD/Behat/README.md
+++ b/DX/BDD/Behat/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/CI/Jenkins/README.md
+++ b/DX/CI/Jenkins/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/CI/Travis/README.md
+++ b/DX/CI/Travis/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Chef/README.md
+++ b/DX/Chef/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Commands/NIX/README.md
+++ b/DX/Commands/NIX/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Commands/Windows/README.md
+++ b/DX/Commands/Windows/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Commands/macOS/README.md
+++ b/DX/Commands/macOS/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Config/Apache/README.md
+++ b/DX/Config/Apache/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Config/Nginx/README.md
+++ b/DX/Config/Nginx/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Docker/README.md
+++ b/DX/Docker/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Documentation/README.md
+++ b/DX/Documentation/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Linting/README.md
+++ b/DX/Linting/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Minification/README.md
+++ b/DX/Minification/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Platform_sh/README.md
+++ b/DX/Platform_sh/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/README.md
+++ b/DX/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/AngularJS/README.md
+++ b/DX/SDKs/AngularJS/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/Dart/README.md
+++ b/DX/SDKs/Dart/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/Ember/README.md
+++ b/DX/SDKs/Ember/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/Java/README.md
+++ b/DX/SDKs/Java/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/Python/README.md
+++ b/DX/SDKs/Python/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/README.md
+++ b/DX/SDKs/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/React/README.md
+++ b/DX/SDKs/React/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/Ruby/README.md
+++ b/DX/SDKs/Ruby/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/TypeScript/README.md
+++ b/DX/SDKs/TypeScript/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/SDKs/Vue/README.md
+++ b/DX/SDKs/Vue/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Task Runners/README.md
+++ b/DX/Task Runners/README.md
@@ -10,6 +10,6 @@ recommendations and support of task runners for eZ Platform projects.
 ---
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Training/README.md
+++ b/DX/Training/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/Vagrant/README.md
+++ b/DX/Vagrant/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/VirtualBox/README.md
+++ b/DX/VirtualBox/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/a11y/README.md
+++ b/DX/a11y/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/DX/i18n/README.md
+++ b/DX/i18n/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are only a few files here while we ramp up this new approach (this
 repository was born on February 8, 2017). The `v2.0` branch is where you'll
 find most of our initial activity, PRs, and discussion:
 
-https://github.com/ezsystems/specs/tree/v2.0
+https://github.com/ezsystems/requirements/tree/v2.0
 
 ### What are all these empty folders?
 

--- a/eZ Platform/APIs/Authentication/README.md
+++ b/eZ Platform/APIs/Authentication/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/APIs/GraphQL/README.md
+++ b/eZ Platform/APIs/GraphQL/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/APIs/PHP/README.md
+++ b/eZ Platform/APIs/PHP/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/APIs/README.md
+++ b/eZ Platform/APIs/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/APIs/REST/README.md
+++ b/eZ Platform/APIs/REST/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Content Type View/README.md
+++ b/eZ Platform/Admin UI/Content Type View/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Dashboard/README.md
+++ b/eZ Platform/Admin UI/Dashboard/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Multi-File Upload/README.md
+++ b/eZ Platform/Admin UI/Multi-File Upload/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Online Editor/README.md
+++ b/eZ Platform/Admin UI/Online Editor/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Permissions/README.md
+++ b/eZ Platform/Admin UI/Permissions/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/README.md
+++ b/eZ Platform/Admin UI/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Translation/Main Translation Selection/README.md
+++ b/eZ Platform/Admin UI/Translation/Main Translation Selection/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Translation/README.md
+++ b/eZ Platform/Admin UI/Translation/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Translation/Translation Creation/README.md
+++ b/eZ Platform/Admin UI/Translation/Translation Creation/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Translation/Translation Editing/README.md
+++ b/eZ Platform/Admin UI/Translation/Translation Editing/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Universal Discovery Widget/Browse/README.md
+++ b/eZ Platform/Admin UI/Universal Discovery Widget/Browse/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Universal Discovery Widget/Content Tree/README.md
+++ b/eZ Platform/Admin UI/Universal Discovery Widget/Content Tree/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Universal Discovery Widget/Content on the Fly/README.md
+++ b/eZ Platform/Admin UI/Universal Discovery Widget/Content on the Fly/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Universal Discovery Widget/README.md
+++ b/eZ Platform/Admin UI/Universal Discovery Widget/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Admin UI/Universal Discovery Widget/Select Content/README.md
+++ b/eZ Platform/Admin UI/Universal Discovery Widget/Select Content/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Assetic/README.md
+++ b/eZ Platform/Assetic/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Config/YAML/README.md
+++ b/eZ Platform/Config/YAML/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/CotF/README.md
+++ b/eZ Platform/CotF/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Doctrine/README.md
+++ b/eZ Platform/Doctrine/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Legacy Bridge/README.md
+++ b/eZ Platform/Legacy Bridge/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/README.md
+++ b/eZ Platform/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Repo/README.md
+++ b/eZ Platform/Repo/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Support Tools/README.md
+++ b/eZ Platform/Support Tools/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Twig/README.md
+++ b/eZ Platform/Twig/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/

--- a/eZ Platform/Views/README.md
+++ b/eZ Platform/Views/README.md
@@ -2,6 +2,6 @@
 
 This is the Requirements & Specifications repository for eZ Platform.
 
-https://github.com/ezsystems/specs
+https://github.com/ezsystems/requirements
 
 https://ezplatform.com/


### PR DESCRIPTION
Files moved over from the old /specs repo updated to reference the new /requirements repo.

Automatic search-and-replace run project-wide in Atom 1.13.1